### PR TITLE
Dart: use latest template & official Docker image

### DIFF
--- a/community/samples/serving/helloworld-dart/Dockerfile
+++ b/community/samples/serving/helloworld-dart/Dockerfile
@@ -1,7 +1,21 @@
-# Use Google's official Dart image.
-# https://hub.docker.com/r/google/dart-runtime/
-FROM google/dart-runtime
+# Use latest stable channel SDK.
+FROM dart:stable AS build
 
-# ONBUILD instructions for COPY and pub get is defined in the google/dart-runtime image,
-# allowing you to keep this file very simple, see:
-# https://github.com/dart-lang/dart_docker/blob/master/runtime/Dockerfile.template#L15-L18
+# Resolve app dependencies.
+WORKDIR /app
+COPY pubspec.* ./
+RUN dart pub get
+
+# Copy app source code (except anything in .dockerignore) and AOT compile app.
+COPY . .
+RUN dart compile exe bin/server.dart -o bin/server
+
+# Build minimal serving image from AOT-compiled `/server`
+# and the pre-built AOT-runtime in the `/runtime/` directory of the base image.
+FROM scratch
+COPY --from=build /runtime/ /
+COPY --from=build /app/bin/server /app/bin/
+
+# Start server.
+EXPOSE 8080
+CMD ["/app/bin/server"]

--- a/community/samples/serving/helloworld-dart/README.md
+++ b/community/samples/serving/helloworld-dart/README.md
@@ -22,68 +22,24 @@ that you can use for testing. It reads in the env variable `TARGET` and prints
 
 ## Recreating the sample code
 
-While you can clone all of the code from this directory, it is useful to know
-how to build a hello world Dart application step-by-step. This application can
-be created using the following instructions.
+While you can clone all of the code from this directory, we recommend you create
+your hello world Dart application by using the `dart` developer tool. This takes
+just a few steps:
 
-1. Create a new directory and write `pubspec.yaml` as follows:
+1. Create a new Dart app using the `server_shelf` template:
 
-   ```yaml
-   name: hello_world_dart
-   publish_to: none # let's not accidentally publish this to pub.dartlang.org
-   description: Hello world server example in Dart
-
-   environment:
-     sdk: ">=2.1.0 <3.0.0"
-
-   dependencies:
-     shelf: ^0.7.3
+   ```shell
+   > create -t server-shelf helloworld-dart 
    ```
 
-2. If you want to run locally, install dependencies. If you only want to run in
+1. If you want to run locally, install dependencies. If you only want to run in
    Docker or Knative, you can skip this step.
 
    ```shell
-   > pub get
+   > dart pub get
    ```
 
-3. Create a new file `bin/server.dart` and write the following code:
-
-   ```dart
-   import 'dart:io';
-
-   import 'package:shelf/shelf.dart';
-   import 'package:shelf/shelf_io.dart';
-
-   Future main() async {
-     // Find port to listen on from environment variable.
-     var port = int.tryParse(Platform.environment['PORT'] ?? '8080');
-
-     // Read $TARGET from environment variable.
-     var target = Platform.environment['TARGET'] ?? 'World';
-
-     Response handler(Request request) => Response.ok('Hello $target');
-
-     // Serve handler on given port.
-     var server = await serve(
-       Pipeline().addMiddleware(logRequests()).addHandler(handler),
-       InternetAddress.anyIPv4,
-       port,
-     );
-     print('Serving at http://${server.address.host}:${server.port}');
-   }
-   ```
-
-4. Create a new file named `Dockerfile`, this file defines instructions for
-   dockerizing your applications, for dart apps this can be done as follows:
-
-   ```Dockerfile
-   # Use Google's official Dart image.
-   # https://hub.docker.com/r/google/dart-runtime/
-   FROM google/dart-runtime
-   ```
-
-5. Create a new file, `service.yaml` and copy the following service definition
+1. Create a new file, `service.yaml` and copy the following service definition
    into the file. Make sure to replace `{username}` with your Docker Hub
    username.
 

--- a/community/samples/serving/helloworld-dart/analysis_options.yaml
+++ b/community/samples/serving/helloworld-dart/analysis_options.yaml
@@ -1,0 +1,29 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/community/samples/serving/helloworld-dart/bin/server.dart
+++ b/community/samples/serving/helloworld-dart/bin/server.dart
@@ -2,21 +2,31 @@ import 'dart:io';
 
 import 'package:shelf/shelf.dart';
 import 'package:shelf/shelf_io.dart';
+import 'package:shelf_router/shelf_router.dart';
 
-Future main() async {
-  // Find port to listen on from environment variable.
-  var port = int.tryParse(Platform.environment['PORT'] ?? '8080');
+// Configure routes.
+final _router = Router()
+  ..get('/', _rootHandler)
+  ..get('/echo/<message>', _echoHandler);
 
-  // Read $TARGET from environment variable.
-  var target = Platform.environment['TARGET'] ?? 'World';
+Response _rootHandler(Request req) {
+  return Response.ok('Hello, World!\n');
+}
 
-  Response handler(Request request) => Response.ok('Hello $target');
+Response _echoHandler(Request request) {
+  final message = request.params['message'];
+  return Response.ok('$message\n');
+}
 
-  // Serve handler on given port.
-  var server = await serve(
-    Pipeline().addMiddleware(logRequests()).addHandler(handler),
-    InternetAddress.anyIPv4,
-    port,
-  );
-  print('Serving at http://${server.address.host}:${server.port}');
+void main(List<String> args) async {
+  // Use any available host or container IP (usually `0.0.0.0`).
+  final ip = InternetAddress.anyIPv4;
+
+  // Configure a pipeline that logs requests.
+  final handler = Pipeline().addMiddleware(logRequests()).addHandler(_router);
+
+  // For running in containers, we respect the PORT environment variable.
+  final port = int.parse(Platform.environment['PORT'] ?? '8080');
+  final server = await serve(handler, ip, port);
+  print('Server listening on port ${server.port}');
 }

--- a/community/samples/serving/helloworld-dart/pubspec.yaml
+++ b/community/samples/serving/helloworld-dart/pubspec.yaml
@@ -2,7 +2,12 @@ name: hello_world_dart
 publish_to: none # let's not accidentally publish this to pub.dartlang.org
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  shelf: ^0.7.3
+  args: ^2.0.0
+  shelf: ^1.1.0
+  shelf_router: ^1.0.0
+
+dev_dependencies:
+  lints: ^2.0.0


### PR DESCRIPTION
Fixes the Dart example to use the new Docker Official Dart image, and to use the latest Dart server template.

## Proposed Changes <!-- Describe the changes the PR makes. -->

- Move from Docker image `google/dart-runtime` to `dart:stable`
- Change README to use `dart create` to create most file content
- Align file content with the `server_shelf` template
